### PR TITLE
fix syntax on range_query.rb

### DIFF
--- a/lib/chartable/range_query.rb
+++ b/lib/chartable/range_query.rb
@@ -13,12 +13,13 @@ module Chartable
 
       return scope if from_date.nil? && to_date.nil?
 
-      if from_date.nil?
-        scope.where("DATE(#{on}) <= ?", to_date.to_date)
-      elsif to_date.nil?
-        scope.where("DATE(#{on}) >= ?", from_date.to_date)
-      else
-        scope.where("DATE(#{on}) >= ? AND DATE(#{on}) <= ?", from_date.to_date, to_date.to_date)
+      case
+        when from_date.nil?
+          scope.where("DATE(#{on}) <= ?", to_date.to_date)
+        when to_date.nil?
+          scope.where("DATE(#{on}) >= ?", from_date.to_date)
+        else
+          scope.where("DATE(#{on}) >= ? AND DATE(#{on}) <= ?", from_date.to_date, to_date.to_date)
       end
     end
   end


### PR DESCRIPTION
Fix syntax in `range_query.rb` for better readable.

```diff
diff --git a/lib/chartable/range_query.rb b/lib/chartable/range_query.rb
index e58ea8d..3431dc5 100644
--- a/lib/chartable/range_query.rb
+++ b/lib/chartable/range_query.rb
@@ -13,12 +13,13 @@ module Chartable
 
       return scope if from_date.nil? && to_date.nil?
 
-      if from_date.nil?
-        scope.where("DATE(#{on}) <= ?", to_date.to_date)
-      elsif to_date.nil?
-        scope.where("DATE(#{on}) >= ?", from_date.to_date)
-      else
-        scope.where("DATE(#{on}) >= ? AND DATE(#{on}) <= ?", from_date.to_date, to_date.to_date)
+      case
+        when from_date.nil?
+          scope.where("DATE(#{on}) <= ?", to_date.to_date)
+        when to_date.nil?
+          scope.where("DATE(#{on}) >= ?", from_date.to_date)
+        else
+          scope.where("DATE(#{on}) >= ? AND DATE(#{on}) <= ?", from_date.to_date, to_date.to_date)
       end
     end
   end
```